### PR TITLE
Some QOL changes for the kafka-hello-world project

### DIFF
--- a/kafka-hello-world/pom.xml
+++ b/kafka-hello-world/pom.xml
@@ -103,24 +103,25 @@
       <artifactId>scala-library</artifactId>
       <version>${scala.version}</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients -->
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
       <version>2.7.0</version>
     </dependency>
-
-    <!-- https://mvnrepository.com/artifact/net.liftweb/lift-json -->
     <dependency>
       <groupId>net.liftweb</groupId>
       <artifactId>lift-json_2.12</artifactId>
       <version>3.4.3</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/it.bitbl/scala-faker -->
     <dependency>
       <groupId>it.bitbl</groupId>
       <artifactId>scala-faker_2.12</artifactId>
       <version>0.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.30</version>
     </dependency>
   </dependencies>
 </project>

--- a/kafka-hello-world/src/main/resources/simplelogger.properties
+++ b/kafka-hello-world/src/main/resources/simplelogger.properties
@@ -1,0 +1,34 @@
+# SLF4J's SimpleLogger configuration file
+
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=error
+
+# Logging detail level for a SimpleLogger instance named "xxxxx".
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used.
+org.slf4j.simpleLogger.log.com.labs1904=debug
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+#org.slf4j.simpleLogger.showDateTime=false
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+#org.slf4j.simpleLogger.showThreadName=true
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogName=true
+
+# Set to true if you want the last component of the name to be included in output messages.
+# Defaults to false.
+#org.slf4j.simpleLogger.showShortLogName=false

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/ConnectionTest.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/ConnectionTest.scala
@@ -4,12 +4,14 @@ import com.labs1904.hwe.util.Constants._
 import com.labs1904.hwe.util.Util
 import net.liftweb.json.DefaultFormats
 import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, KafkaConsumer}
+import org.slf4j.LoggerFactory
 
 import java.time.Duration
 import java.util.Arrays
 
 object ConnectionTest {
   implicit val formats: DefaultFormats.type = DefaultFormats
+  private val logger = LoggerFactory.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {
     // Create the KafkaConsumer
@@ -29,7 +31,7 @@ object ConnectionTest {
       records.forEach((record: ConsumerRecord[String, String]) => {
         // Retrieve the message from each record
         val message = record.value()
-        println(s"Message Received: $message")
+        logger.info(s"Message Received: $message")
       })
     }
   }

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/ConnectionTest.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/ConnectionTest.scala
@@ -1,33 +1,23 @@
 package com.labs1904.hwe.consumers
 
+import com.labs1904.hwe.util.Constants._
 import com.labs1904.hwe.util.Util
 import net.liftweb.json.DefaultFormats
-import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, ConsumerRecords, KafkaConsumer}
-import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, KafkaConsumer}
 
 import java.time.Duration
-import java.util.{Arrays, Properties, UUID}
+import java.util.Arrays
 
 object ConnectionTest {
-  // TODO: this is configured to use kafka running locally, change it to your cluster
-  val BootstrapServer : String = "CHANGEME"
-  val Topic: String = "hwe-kafka-connection-test"
-  val username: String = "CHANGEME"
-  val password: String = "CHANGEME"
-  //Use this for Windows
-  val trustStore: String = "src\\main\\resources\\kafka.client.truststore.jks"
-  //Use this for Mac
-  //val trustStore: String = "src/main/resources/kafka.client.truststore.jks"
-
   implicit val formats: DefaultFormats.type = DefaultFormats
 
   def main(args: Array[String]): Unit = {
     // Create the KafkaConsumer
-    val properties = getProperties(BootstrapServer)
+    val properties = Util.getConsumerProperties(BOOTSTRAP_SERVER)
     val consumer: KafkaConsumer[String, String] = new KafkaConsumer[String, String](properties)
 
     // Subscribe to the topic
-    consumer.subscribe(Arrays.asList(Topic))
+    consumer.subscribe(Arrays.asList(DEFAULT_TOPIC))
 
     while ( {
       true
@@ -43,21 +33,4 @@ object ConnectionTest {
       })
     }
   }
-
-  def getProperties(bootstrapServer: String): Properties = {
-    // Set Properties to be used for Kafka Consumer
-    val properties = new Properties
-    properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer)
-    properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
-    properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
-    properties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString)
-
-    properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-    properties.put("security.protocol", "SASL_SSL")
-    properties.put("sasl.mechanism", "SCRAM-SHA-512")
-    properties.put("ssl.truststore.location", trustStore)
-    properties.put("sasl.jaas.config", Util.getScramAuthString(username, password))
-    properties
-  }
-
 }

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/HweConsumer.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/HweConsumer.scala
@@ -1,37 +1,29 @@
 package com.labs1904.hwe.consumers
 
-import com.labs1904.hwe.producers.SimpleProducer
+import com.labs1904.hwe.util.Constants._
 import com.labs1904.hwe.util.Util
-import com.labs1904.hwe.util.Util.getScramAuthString
 import net.liftweb.json.DefaultFormats
-import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, ConsumerRecords, KafkaConsumer}
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
-import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, KafkaConsumer}
+import org.apache.kafka.clients.producer.KafkaProducer
 
 import java.time.Duration
-import java.util.{Arrays, Properties, UUID}
+import java.util.Arrays
 
 object HweConsumer {
-  val BootstrapServer : String = "CHANGEME"
+
   val consumerTopic: String = "question-1"
   val producerTopic: String = "question-1-output"
-  val username: String = "CHANGEME"
-  val password: String = "CHANGEME"
-  //Use this for Windows
-  val trustStore: String = "src\\main\\resources\\kafka.client.truststore.jks"
-  //Use this for Mac
-  //val trustStore: String = "src/main/resources/kafka.client.truststore.jks"
 
   implicit val formats: DefaultFormats.type = DefaultFormats
 
   def main(args: Array[String]): Unit = {
 
     // Create the KafkaConsumer
-    val consumerProperties = SimpleConsumer.getProperties(BootstrapServer)
+    val consumerProperties = Util.getConsumerProperties(BOOTSTRAP_SERVER)
     val consumer: KafkaConsumer[String, String] = new KafkaConsumer[String, String](consumerProperties)
 
     // Create the KafkaProducer
-    val producerProperties = SimpleProducer.getProperties(BootstrapServer)
+    val producerProperties = Util.getProperties(BOOTSTRAP_SERVER)
     val producer = new KafkaProducer[String, String](producerProperties)
 
     // Subscribe to the topic

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/HweConsumer.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/HweConsumer.scala
@@ -5,11 +5,13 @@ import com.labs1904.hwe.util.Util
 import net.liftweb.json.DefaultFormats
 import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, KafkaConsumer}
 import org.apache.kafka.clients.producer.KafkaProducer
+import org.slf4j.LoggerFactory
 
 import java.time.Duration
 import java.util.Arrays
 
 object HweConsumer {
+  private val logger = LoggerFactory.getLogger(getClass)
 
   val consumerTopic: String = "question-1"
   val producerTopic: String = "question-1-output"
@@ -39,7 +41,7 @@ object HweConsumer {
       records.forEach((record: ConsumerRecord[String, String]) => {
         // Retrieve the message from each record
         val message = record.value()
-        println(s"Message Received: $message")
+        logger.info(s"Message Received: $message")
         // TODO: Add business logic here!
 
       })

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/JSONConsumer.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/JSONConsumer.scala
@@ -4,11 +4,14 @@ import com.labs1904.hwe.util.Constants._
 import com.labs1904.hwe.util.Util
 import net.liftweb.json.DefaultFormats
 import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, KafkaConsumer}
+import org.slf4j.LoggerFactory
 
 import java.time.Duration
 import java.util
 
 object JSONConsumer {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   implicit val formats: DefaultFormats.type = DefaultFormats
 
   def main(args: Array[String]): Unit = {
@@ -29,8 +32,8 @@ object JSONConsumer {
       records.forEach((record: ConsumerRecord[String, String]) => {
         /*
           // DEBUG Info
-          println(s"Key: ${record.key}. Value: ${record.value}")
-          println(s"Partition: ${record.partition}, Offset ${record.offset}")
+          logger.info(s"Key: ${record.key}. Value: ${record.value}")
+          logger.info(s"Partition: ${record.partition}, Offset ${record.offset}")
         */
 
         /*
@@ -40,7 +43,7 @@ object JSONConsumer {
          */
 
         val message = record.value()
-        println(s"Message Received: $message")
+        logger.info(s"Message Received: $message")
       })
     }
   }

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/JSONConsumer.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/JSONConsumer.scala
@@ -1,34 +1,23 @@
 package com.labs1904.hwe.consumers
 
-import com.labs1904.hwe.util.Util.getScramAuthString
-import net.liftweb.json.{DefaultFormats, parse}
-import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, ConsumerRecords, KafkaConsumer}
-import org.apache.kafka.common.serialization.StringDeserializer
+import com.labs1904.hwe.util.Constants._
+import com.labs1904.hwe.util.Util
+import net.liftweb.json.DefaultFormats
+import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, KafkaConsumer}
 
 import java.time.Duration
 import java.util
-import java.util.{Properties, UUID}
 
 object JSONConsumer {
-
-  val BootstrapServer : String = "CHANGEME"
-  val Topic: String = "CHANGEME"
-  val username: String = "CHANGEME"
-  val password: String = "CHANGEME"
-  //Use this for Windows
-  val trustStore: String = "src\\main\\resources\\kafka.client.truststore.jks"
-  //Use this for Mac
-  //val trustStore: String = "src/main/resources/kafka.client.truststore.jks"
-
   implicit val formats: DefaultFormats.type = DefaultFormats
 
   def main(args: Array[String]): Unit = {
     // Create the KafkaConsumer
-    val properties = getProperties(BootstrapServer)
+    val properties = Util.getConsumerProperties(BOOTSTRAP_SERVER)
     val consumer: KafkaConsumer[String, String] = new KafkaConsumer[String, String](properties)
 
     // Subscribe to the topic
-    consumer.subscribe(util.Arrays.asList(Topic))
+    consumer.subscribe(util.Arrays.asList(DEFAULT_TOPIC))
 
     while ( {
       true
@@ -54,22 +43,5 @@ object JSONConsumer {
         println(s"Message Received: $message")
       })
     }
-  }
-
-  def getProperties(bootstrapServer: String): Properties = {
-    // Set Properties to be used for Kafka Consumer
-    val properties = new Properties
-    properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer)
-    properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
-    properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
-    properties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString)
-    properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-
-    properties.put("security.protocol", "SASL_SSL")
-    properties.put("sasl.mechanism", "SCRAM-SHA-512")
-    properties.put("ssl.truststore.location", trustStore)
-    properties.put("sasl.jaas.config", getScramAuthString(username, password))
-
-    properties
   }
 }

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/SimpleConsumer.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/SimpleConsumer.scala
@@ -1,33 +1,24 @@
 package com.labs1904.hwe.consumers
 
-import com.labs1904.hwe.util.Util.getScramAuthString
+import com.labs1904.hwe.util.Constants._
+import com.labs1904.hwe.util.Util
 import net.liftweb.json.DefaultFormats
-import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, ConsumerRecords, KafkaConsumer}
-import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, KafkaConsumer}
 
 import java.time.Duration
-import java.util.{Arrays, Properties, UUID}
+import java.util.Arrays
 
 object SimpleConsumer {
-  val BootstrapServer : String = "CHANGEME"
-  val Topic: String = "question-1"
-  val username: String = "CHANGEME"
-  val password: String = "CHANGEME"
-  //Use this for Windows
-  val trustStore: String = "src\\main\\resources\\kafka.client.truststore.jks"
-  //Use this for Mac
-  //val trustStore: String = "src/main/resources/kafka.client.truststore.jks"
-
   implicit val formats: DefaultFormats.type = DefaultFormats
 
   def main(args: Array[String]): Unit = {
 
     // Create the KafkaConsumer
-    val properties = getProperties(BootstrapServer)
+    val properties = Util.getConsumerProperties(BOOTSTRAP_SERVER)
     val consumer: KafkaConsumer[String, String] = new KafkaConsumer[String, String](properties)
 
     // Subscribe to the topic
-    consumer.subscribe(Arrays.asList(Topic))
+    consumer.subscribe(Arrays.asList(DEFAULT_TOPIC))
 
     while ( {
       true
@@ -42,22 +33,5 @@ object SimpleConsumer {
         println(s"Message Received: $message")
       })
     }
-  }
-
-  def getProperties(bootstrapServer: String): Properties = {
-    // Set Properties to be used for Kafka Consumer
-    val properties = new Properties
-    properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer)
-    properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
-    properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
-    properties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString)
-    properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-
-    properties.put("security.protocol", "SASL_SSL")
-    properties.put("sasl.mechanism", "SCRAM-SHA-512")
-    properties.put("ssl.truststore.location", trustStore)
-    properties.put("sasl.jaas.config", getScramAuthString(username, password))
-
-    properties
   }
 }

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/SimpleConsumer.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/consumers/SimpleConsumer.scala
@@ -4,11 +4,14 @@ import com.labs1904.hwe.util.Constants._
 import com.labs1904.hwe.util.Util
 import net.liftweb.json.DefaultFormats
 import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, KafkaConsumer}
+import org.slf4j.LoggerFactory
 
 import java.time.Duration
 import java.util.Arrays
 
 object SimpleConsumer {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   implicit val formats: DefaultFormats.type = DefaultFormats
 
   def main(args: Array[String]): Unit = {
@@ -30,7 +33,7 @@ object SimpleConsumer {
       records.forEach((record: ConsumerRecord[String, String]) => {
         // Retrieve the message from each record
         val message = record.value()
-        println(s"Message Received: $message")
+        logger.info(s"Message Received: $message")
       })
     }
   }

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/homework/KafkaHomework.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/homework/KafkaHomework.scala
@@ -6,6 +6,7 @@ import java.util.{Arrays, Properties, UUID}
 import net.liftweb.json.DefaultFormats
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, ConsumerRecords, KafkaConsumer}
 import org.apache.kafka.common.serialization.StringDeserializer
+import com.labs1904.hwe.util.Constants._
 
 object KafkaHomework {
   /**
@@ -14,7 +15,6 @@ object KafkaHomework {
    */
 
     //TODO: If these are given in class, change them so that you can run a test. If not, don't worry about this step
-  val BootstrapServer = "change-me"
   val Topic: String = "change-me"
 
   implicit val formats: DefaultFormats.type = DefaultFormats
@@ -23,7 +23,7 @@ object KafkaHomework {
 
     // Create the KafkaConsumer
     //TODO: Write in a comment what these lines are doing. What are the properties necessary to instantiate a consumer?
-    val properties = getProperties(BootstrapServer)
+    val properties = getProperties(BOOTSTRAP_SERVER)
     val consumer: KafkaConsumer[String, String] = new KafkaConsumer[String, String](properties)
 
 

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/homework/KafkaHomework.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/homework/KafkaHomework.scala
@@ -2,13 +2,15 @@ package com.labs1904.hwe.homework
 
 import java.time.Duration
 import java.util.{Arrays, Properties, UUID}
-
 import net.liftweb.json.DefaultFormats
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, ConsumerRecords, KafkaConsumer}
 import org.apache.kafka.common.serialization.StringDeserializer
 import com.labs1904.hwe.util.Constants._
+import org.slf4j.LoggerFactory
 
 object KafkaHomework {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   /**
    * Your task is to try to understand this code and run the consumer successfully. Follow each step below for completion.
    * Implement all the todos below
@@ -43,7 +45,7 @@ object KafkaHomework {
         val message = record.value()
 
         //TODO: If you were given the values for the bootstrap servers in class, run the app with the green play button and make sure it runs successfully. You should see message(s) printing out to the screen
-        println(s"Message Received: $message")
+        logger.info(s"Message Received: $message")
       })
     }
   }

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/producers/ProducerWithFaker.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/producers/ProducerWithFaker.scala
@@ -5,10 +5,13 @@ import com.labs1904.hwe.util.Util
 import faker._
 import net.liftweb.json.DefaultFormats
 import org.apache.kafka.clients.producer.{Callback, KafkaProducer, ProducerRecord, RecordMetadata}
+import org.slf4j.LoggerFactory
 
 case class User(name: String, username: String, email: String)
 
 object ProducerWithFaker {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   implicit val formats: DefaultFormats.type = DefaultFormats
 
   def main(args: Array[String]): Unit = {
@@ -40,7 +43,7 @@ object ProducerWithFaker {
       producer.send(record, new Callback() {
         override def onCompletion(recordMetadata: RecordMetadata, e: Exception): Unit = {
           if (e == null) {
-            println(
+            logger.info(
               s"""
                  |Sent Record: ${record.value()}
                  |Topic: ${recordMetadata.topic()}
@@ -48,7 +51,7 @@ object ProducerWithFaker {
                  |Offset: ${recordMetadata.offset()}
                  |Timestamp: ${recordMetadata.timestamp()}
           """.stripMargin)
-          } else println("Error while producing", e)
+          } else logger.info("Error while producing", e)
         }
       })
     })

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/producers/ProducerWithFaker.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/producers/ProducerWithFaker.scala
@@ -1,31 +1,20 @@
 package com.labs1904.hwe.producers
 
-import com.labs1904.hwe.util.Util.getScramAuthString
-import org.apache.kafka.clients.producer.{Callback, KafkaProducer, ProducerConfig, ProducerRecord, RecordMetadata}
-import org.apache.kafka.common.serialization.StringSerializer
+import com.labs1904.hwe.util.Constants._
+import com.labs1904.hwe.util.Util
 import faker._
 import net.liftweb.json.DefaultFormats
-import net.liftweb.json.Serialization.write
-
-import java.util.Properties
+import org.apache.kafka.clients.producer.{Callback, KafkaProducer, ProducerRecord, RecordMetadata}
 
 case class User(name: String, username: String, email: String)
 
 object ProducerWithFaker {
   implicit val formats: DefaultFormats.type = DefaultFormats
-  val BootstrapServer : String = "CHANGEME"
-  val Topic: String = "CHANGEME"
-  val username: String = "CHANGEME"
-  val password: String = "CHANGEME"
-  //Use this for Windows
-  val trustStore: String = "src\\main\\resources\\kafka.client.truststore.jks"
-  //Use this for Mac
-  //val trustStore: String = "src/main/resources/kafka.client.truststore.jks"
 
   def main(args: Array[String]): Unit = {
 
     // Create the Kafka Producer
-    val properties = getProperties(BootstrapServer)
+    val properties = Util.getProperties(BOOTSTRAP_SERVER)
     val producer = new KafkaProducer[String, String](properties)
 
     // create n fake records to send to topic
@@ -44,7 +33,7 @@ object ProducerWithFaker {
       //val jsonString = write(user)
       val csvString = key + "," + name.replace(",","") + "," + user.email.replace(",","")
 
-      new ProducerRecord[String, String](Topic, key, csvString)
+      new ProducerRecord[String, String](DEFAULT_TOPIC, key, csvString)
     }).foreach(record => {
 
       // send records to topic
@@ -67,19 +56,5 @@ object ProducerWithFaker {
     producer.close()
   }
 
-  def getProperties(bootstrapServer: String): Properties = {
-    // Set Properties to be used for Kafka Producer
-    val properties = new Properties
-    properties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer)
-    properties.setProperty(ProducerConfig.ACKS_CONFIG, "1")
-    properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer].getName)
-    properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer].getName)
 
-    properties.put("security.protocol", "SASL_SSL")
-    properties.put("sasl.mechanism", "SCRAM-SHA-512")
-    properties.put("ssl.truststore.location", trustStore)
-    properties.put("sasl.jaas.config", getScramAuthString(username, password))
-
-    properties
-  }
 }

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/producers/SimpleProducer.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/producers/SimpleProducer.scala
@@ -1,47 +1,22 @@
 package com.labs1904.hwe.producers
 
-import com.labs1904.hwe.util.Util.getScramAuthString
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
-import org.apache.kafka.common.serialization.StringSerializer
-
-import java.util.Properties
+import com.labs1904.hwe.util.Constants._
+import com.labs1904.hwe.util.Util
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 
 object SimpleProducer {
-  // Set constants
-  val BootstrapServer : String = "CHANGEME"
   val Topic: String = "question-1-output"
-  val username: String = "CHANGEME"
-  val password: String = "CHANGEME"
-  //Use this for Windows
-  val trustStore: String = "src\\main\\resources\\kafka.client.truststore.jks"
-  //Use this for Mac
-  //val trustStore: String = "src/main/resources/kafka.client.truststore.jks"
 
   def main(args: Array[String]): Unit = {
     // Create Kafka Producer
-    val properties = getProperties(BootstrapServer)
+    val properties = Util.getProperties(BOOTSTRAP_SERVER)
     val producer = new KafkaProducer[String, String](properties)
     val messageToSend = "Change Me"
 
     val record = new ProducerRecord[String, String](Topic, messageToSend)
-
     producer.send(record)
-
     producer.close()
   }
 
-  def getProperties(bootstrapServer: String): Properties = {
-    // Set Properties to be used for Kafka Producer
-    val properties = new Properties
-    properties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer)
-    properties.setProperty(ProducerConfig.ACKS_CONFIG, "1")
-    properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer].getName)
-    properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer].getName)
 
-    properties.put("security.protocol", "SASL_SSL")
-    properties.put("sasl.mechanism", "SCRAM-SHA-512")
-    properties.put("ssl.truststore.location", trustStore)
-    properties.put("sasl.jaas.config", getScramAuthString(username, password))
-    properties
-  }
 }

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/util/Constants.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/util/Constants.scala
@@ -1,0 +1,13 @@
+package com.labs1904.hwe.util
+
+object Constants {
+  // TODO: this is configured to use kafka running locally, change it to your cluster
+  val BOOTSTRAP_SERVER : String = "CHANGEME"
+  val DEFAULT_TOPIC: String = "hwe-kafka-connection-test"
+  val USERNAME: String = "CHANGEME"
+  val PASSWORD: String = "CHANGEME"
+  //Use this for Windows
+  val TRUST_STORE: String = "src\\main\\resources\\kafka.client.truststore.jks"
+  //Use this for Mac
+  //val TRUST_STORE: String = "src/main/resources/kafka.client.truststore.jks"
+}

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/util/Constants.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/util/Constants.scala
@@ -1,5 +1,7 @@
 package com.labs1904.hwe.util
 
+import java.nio.file.Paths
+
 object Constants {
   // TODO: this is configured to use kafka running locally, change it to your cluster
   val BOOTSTRAP_SERVER : String = "CHANGEME"
@@ -10,6 +12,6 @@ object Constants {
   val TRUST_STORE: String = {
     val url = getClass.getResource("/kafka.client.truststore.jks")
     if (url == null) throw new Exception("Unable to find kafka.client.truststore.jks in resources, is the project opened correctly?")
-    else url.getPath
+    else Paths.get(url.toURI()).toString
   }
 }

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/util/Constants.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/util/Constants.scala
@@ -7,7 +7,9 @@ object Constants {
   val USERNAME: String = "CHANGEME"
   val PASSWORD: String = "CHANGEME"
   //Use this for Windows
-  val TRUST_STORE: String = "src\\main\\resources\\kafka.client.truststore.jks"
-  //Use this for Mac
-  //val TRUST_STORE: String = "src/main/resources/kafka.client.truststore.jks"
+  val TRUST_STORE: String = {
+    val url = getClass.getResource("/kafka.client.truststore.jks")
+    if (url == null) throw new Exception("Unable to find kafka.client.truststore.jks in resources, is the project opened correctly?")
+    else url.getPath
+  }
 }

--- a/kafka-hello-world/src/main/scala/com/labs1904/hwe/util/Util.scala
+++ b/kafka-hello-world/src/main/scala/com/labs1904/hwe/util/Util.scala
@@ -1,6 +1,46 @@
 package com.labs1904.hwe.util
 
+import com.labs1904.hwe.util.Constants.{PASSWORD, TRUST_STORE, USERNAME}
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
+
+import java.util.{Properties, UUID}
+
 object Util {
+  def getProperties(bootstrapServer: String): Properties = {
+    // Set Properties to be used for Kafka Producer
+    val properties = new Properties
+    properties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer)
+    properties.setProperty(ProducerConfig.ACKS_CONFIG, "1")
+    properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer].getName)
+    properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer].getName)
+
+    properties.put("security.protocol", "SASL_SSL")
+    properties.put("sasl.mechanism", "SCRAM-SHA-512")
+    properties.put("ssl.truststore.location", Constants.TRUST_STORE)
+    properties.put("sasl.jaas.config", getScramAuthString(Constants.USERNAME, Constants.PASSWORD))
+
+    properties
+  }
+
+  def getConsumerProperties(bootstrapServer: String): Properties = {
+    // Set Properties to be used for Kafka Consumer
+    val properties = new Properties
+    properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer)
+    properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
+    properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
+    properties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString)
+    properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+
+    properties.put("security.protocol", "SASL_SSL")
+    properties.put("sasl.mechanism", "SCRAM-SHA-512")
+    properties.put("ssl.truststore.location", TRUST_STORE)
+    properties.put("sasl.jaas.config", getScramAuthString(USERNAME, PASSWORD))
+
+    properties
+  }
+
   def getScramAuthString(username: String, password: String) = {
    s"""org.apache.kafka.common.security.scram.ScramLoginModule required
    username=\"$username\"


### PR DESCRIPTION
Fixed the SLF4J errors being logged to the console and use logger instead of println.
Refactored constants so the user only needs to edit one time.
No manual editing of truststore.